### PR TITLE
fix indent in code example

### DIFF
--- a/topics/cross_book_links.dita
+++ b/topics/cross_book_links.dita
@@ -26,10 +26,10 @@
                 <p>In the source book map, a <term>peer map</term> reference defines a keyscope for
                     each target map that might be referenced by a cross-book link:</p>
                 <codeblock id="codeblock_oss_tds_vrb" outputclass="language-xml">&lt;map>
-                    &lt;title>Book 1&lt;/title>
-                    &lt;mapref href="book2.ditamap" <b>keyscope="book2"</b> processing-role="resource-only" scope="peer"/>
-                    ...
-                    &lt;/map></codeblock>
+    &lt;title>Book 1&lt;/title>
+    &lt;mapref href="book2.ditamap" <b>keyscope="book2"</b> processing-role="resource-only" scope="peer"/>
+        ...
+    &lt;/map></codeblock>
                 <p>In DITA, a peer map is a map that exists alongside your current map. It is a
                     declaration of another map's <i>existence</i>, but not an inclusion of that map
                     for processing or publication.</p>


### PR DESCRIPTION
Signed-off-by: chrispy <chrispy@synopsys.com>

This is a minor fix for over-indenting in a code block element.